### PR TITLE
Update airbrake Heroku addon name

### DIFF
--- a/app.json
+++ b/app.json
@@ -10,7 +10,7 @@
   },
   "addons": [
     "logentries:le_tryit",
-    "airbrake:free_heroku"
+    "airbrake:free-hrku"
   ]
 }
 


### PR DESCRIPTION
Airbrake has changed the addon name for their free plan.
